### PR TITLE
refactor GetWTNames() into helper functions

### DIFF
--- a/WondrousTailsCopier/Plugin.cs
+++ b/WondrousTailsCopier/Plugin.cs
@@ -238,9 +238,8 @@ public sealed class Plugin : IDalamudPlugin
 
     public void RemainingObjectives()
     {
-        var wtData = GetWTNames(forceTrue: "listNumNeeded");
-        var numNeeded = wtData.Substring(wtData.Length - 1);
-        Chat.Print($"You need {numNeeded} objective{(int.Parse(numNeeded) == 1 ? "" : "s")} to finish your Wondrous Tails book.");
+        GetWTDutyList(false, out var numNeeded);
+        Chat.Print($"You need {numNeeded} objective{(numNeeded == 1 ? "" : "s")} to finish your Wondrous Tails book.");
     }
     public void ToClipboard(string displayType = "copy")
     {
@@ -258,24 +257,11 @@ public sealed class Plugin : IDalamudPlugin
     {
         return PlayerState.Instance()->HasWeeklyBingoJournal;
     }
-    public string GetWTNames(string displayType = "copy", string forceTrue = "")
+    public string GetWTNames(string displayType = "copy")
     {
         bool reducedText = Configuration.ReducedTextBool;
         bool excludeCompleted = Configuration.ExcludeCompletedBool;
         bool listNumNeeded = Configuration.ListNumNeededBool;
-
-        if (forceTrue.Contains("reducedText"))
-        {
-            reducedText = true;
-        }
-        else if (forceTrue.Contains("excludeCompleted"))
-        {
-            excludeCompleted = true;
-        }
-        else if (forceTrue.Contains("listNumNeeded"))
-        {
-            listNumNeeded = true;
-        }
 
         if (!HasWT())
         {

--- a/WondrousTailsCopier/Plugin.cs
+++ b/WondrousTailsCopier/Plugin.cs
@@ -289,6 +289,10 @@ public sealed class Plugin : IDalamudPlugin
         {
             dutyList = dutyList.Select(ReduceWTDutyName).ToList();
         }
+        if (listNumNeeded)
+        {
+            dutyList.Add("need {numNeeded}");
+        }
 
         foreach (var dutyLocation in dutyList)
         {
@@ -301,10 +305,6 @@ public sealed class Plugin : IDalamudPlugin
                 tasksInWT += $"{dutyLocation} \n";
             }
 
-        }
-        if (listNumNeeded && displayType == "copy")
-        {
-            tasksInWT += $"need {numNeeded}, ";
         }
         return tasksInWT.Substring(0, tasksInWT.Length - 2);
 

--- a/WondrousTailsCopier/Plugin.cs
+++ b/WondrousTailsCopier/Plugin.cs
@@ -282,7 +282,6 @@ public sealed class Plugin : IDalamudPlugin
             Chat.Print("How'd you get here without having a Wondrous Tails book??");
             return "Missing Wondrous Tails book. Fix me.";
         }
-        var tasksInWT = "";
         var dutyList = GetWTDutyList(excludeCompleted, out int numNeeded);
 
         if (reducedText)
@@ -293,21 +292,7 @@ public sealed class Plugin : IDalamudPlugin
         {
             dutyList.Add("need {numNeeded}");
         }
-
-        foreach (var dutyLocation in dutyList)
-        {
-            if (displayType == "copy")
-            {
-                tasksInWT += $"{dutyLocation}, ";
-            }
-            else // if (displayType == "list")
-            {
-                tasksInWT += $"{dutyLocation} \n";
-            }
-
-        }
-        return tasksInWT.Substring(0, tasksInWT.Length - 2);
-
+        return string.Join(displayType == "copy" ? ", " : "\n", dutyList);
     }
 
     private void DrawUI() => WindowSystem.Draw();

--- a/WondrousTailsCopier/Plugin.cs
+++ b/WondrousTailsCopier/Plugin.cs
@@ -82,11 +82,11 @@ public sealed class Plugin : IDalamudPlugin
         // in response to the slash command, just toggle the display status of our main ui
         if (args == "copy")
         {
-            ToClipboard();
+            ToClipboard(", ");
         }
         else if (args == "copy list")
         {
-            ToClipboard("list");
+            ToClipboard("\n");
         }
         else if (args == "needed")
         {
@@ -241,11 +241,11 @@ public sealed class Plugin : IDalamudPlugin
         GetWTDutyList(false, out var numNeeded);
         Chat.Print($"You need {numNeeded} objective{(numNeeded == 1 ? "" : "s")} to finish your Wondrous Tails book.");
     }
-    public void ToClipboard(string displayType = "copy")
+    public void ToClipboard(string separator)
     {
         if (HasWT())
         {
-            ImGui.SetClipboardText(GetWTNames(displayType));
+            ImGui.SetClipboardText(GetWTNames(separator));
             Chat.Print("Wondrous Tails objectives copied to clipboard.");
         }
         else
@@ -257,7 +257,7 @@ public sealed class Plugin : IDalamudPlugin
     {
         return PlayerState.Instance()->HasWeeklyBingoJournal;
     }
-    public string GetWTNames(string displayType = "copy")
+    public string GetWTNames(string separator)
     {
         bool reducedText = Configuration.ReducedTextBool;
         bool excludeCompleted = Configuration.ExcludeCompletedBool;
@@ -278,7 +278,7 @@ public sealed class Plugin : IDalamudPlugin
         {
             dutyList.Add("need {numNeeded}");
         }
-        return string.Join(displayType == "copy" ? ", " : "\n", dutyList);
+        return string.Join(separator, dutyList);
     }
 
     private void DrawUI() => WindowSystem.Draw();

--- a/WondrousTailsCopier/Plugin.cs
+++ b/WondrousTailsCopier/Plugin.cs
@@ -284,15 +284,14 @@ public sealed class Plugin : IDalamudPlugin
         }
         var tasksInWT = "";
         var dutyList = GetWTDutyList(excludeCompleted, out int numNeeded);
-        foreach (var duty in dutyList)
+
+        if (reducedText)
         {
-            var dutyLocation = duty;
+            dutyList = dutyList.Select(ReduceWTDutyName).ToList();
+        }
 
-            if (reducedText)
-            {
-                dutyLocation = ReduceWTDutyName(dutyLocation);
-            }
-
+        foreach (var dutyLocation in dutyList)
+        {
             if (displayType == "copy")
             {
                 tasksInWT += $"{dutyLocation}, ";

--- a/WondrousTailsCopier/Plugin.cs
+++ b/WondrousTailsCopier/Plugin.cs
@@ -259,9 +259,9 @@ public sealed class Plugin : IDalamudPlugin
     }
     public string GetWTNames(string separator)
     {
-        bool reducedText = Configuration.ReducedTextBool;
-        bool excludeCompleted = Configuration.ExcludeCompletedBool;
-        bool listNumNeeded = Configuration.ListNumNeededBool;
+        var reducedText = Configuration.ReducedTextBool;
+        var excludeCompleted = Configuration.ExcludeCompletedBool;
+        var listNumNeeded = Configuration.ListNumNeededBool;
 
         if (!HasWT())
         {

--- a/WondrousTailsCopier/Plugin.cs
+++ b/WondrousTailsCopier/Plugin.cs
@@ -128,21 +128,21 @@ public sealed class Plugin : IDalamudPlugin
     }
     public unsafe string GetWTNames(string displayType = "copy", string forceTrue = "")
     {
-        bool reducedTextBool = Configuration.ReducedTextBool;
-        bool excludeCompletedBool = Configuration.ExcludeCompletedBool;
-        bool listNumNeededBool = Configuration.ListNumNeededBool;
+        bool reducedText = Configuration.ReducedTextBool;
+        bool excludeCompleted = Configuration.ExcludeCompletedBool;
+        bool listNumNeeded = Configuration.ListNumNeededBool;
 
         if (forceTrue.Contains("reducedText"))
         {
-            reducedTextBool = true;
+            reducedText = true;
         }
         else if (forceTrue.Contains("excludeCompleted"))
         {
-            excludeCompletedBool = true;
+            excludeCompleted = true;
         }
         else if (forceTrue.Contains("listNumNeeded"))
         {
-            listNumNeededBool = true;
+            listNumNeeded = true;
         }
 
         if (!HasWT())
@@ -162,7 +162,7 @@ public sealed class Plugin : IDalamudPlugin
             if (bingoState != PlayerState.WeeklyBingoTaskStatus.Open)
             {
                 numCompleted++;
-                if (excludeCompletedBool)
+                if (excludeCompleted)
                 {
                     continue;
                 }
@@ -185,7 +185,7 @@ public sealed class Plugin : IDalamudPlugin
                 dutyLocation = bingoOrderData.Text.Value.Description.ToString();
             }
 
-            if (reducedTextBool)
+            if (reducedText)
             {
                 if (dutyLocation.Contains("Dungeons "))
                 {
@@ -280,7 +280,7 @@ public sealed class Plugin : IDalamudPlugin
             }
 
         }
-        if (listNumNeededBool && displayType == "copy")
+        if (listNumNeeded && displayType == "copy")
         {
             tasksInWT += $"need {9 - numCompleted}, ";
         }

--- a/WondrousTailsCopier/Plugin.cs
+++ b/WondrousTailsCopier/Plugin.cs
@@ -144,6 +144,93 @@ public sealed class Plugin : IDalamudPlugin
         return dutyList;
     }
 
+    private string ReduceWTDutyName(string dutyLocation)
+    {
+        if (dutyLocation.Contains("Dungeons "))
+        {
+            var pattern = @"Dungeons \(Lv\. (\d+-\d+|\d+)";
+            var r = new Regex(pattern);
+            var m = r.Match(dutyLocation);
+            dutyLocation = m.Groups[1].Value;
+        }
+        else if (dutyLocation.Contains("Alliance Raids"))
+        {
+            if (dutyLocation.Contains("A Realm Reborn"))
+            {
+                dutyLocation = "ARR";
+            }
+            else if (dutyLocation.Contains("Heavensward"))
+            {
+                dutyLocation = "HW";
+            }
+            else if (dutyLocation.Contains("Stormblood"))
+            {
+                dutyLocation = "StB";
+            }
+            else if (dutyLocation.Contains("Shadowbringers"))
+            {
+                dutyLocation = "ShB";
+            }
+            else if (dutyLocation.Contains("Endwalker"))
+            {
+                dutyLocation = "EW";
+            }
+            else if (dutyLocation.Contains("Dawntrail"))
+            {
+                dutyLocation = "DT";
+            }
+            dutyLocation += " AR";
+        }
+        else if (dutyLocation.Contains("of Bahamut"))
+        {
+            // May be problematic if they go back to specific "Turn x" objectives
+            var pattern = @"(.*) of Bahamut";
+            var r = new Regex(pattern);
+            var m = r.Match(dutyLocation);
+            dutyLocation = m.Groups[1].Value;
+        }
+        else if (dutyLocation.Contains("-heavyweight"))
+        {
+            var pattern = @"(AAC) \w+-heavyweight (.*)";
+            var r = new Regex(pattern);
+            var m = r.Match(dutyLocation);
+            dutyLocation = $"{m.Groups[1].Value} {m.Groups[2].Value}";
+        }
+        else if (dutyLocation.Contains("Extreme"))
+        {
+            var pattern = @"(?:the )?(.*) \(Extreme\)";
+            var r = new Regex(pattern);
+            var m = r.Match(dutyLocation);
+            dutyLocation = m.Groups[1].Value;
+            if (dutyLocation.Contains("Containment Bay"))
+            {
+                var splitCB = dutyLocation.Split(' ');
+                dutyLocation = splitCB[2];
+            }
+        }
+        else if (dutyLocation.Contains("Minstrel's Ballad"))
+        {
+            var pattern = @"the Minstrel's Ballad: (.*)";
+            var r = new Regex(pattern);
+            var m = r.Match(dutyLocation);
+            dutyLocation = m.Groups[1].Value;
+        }
+        else if (dutyLocation == "Crystalline Conflict")
+        {
+            dutyLocation = "CC";
+        }
+        else if (dutyLocation == "Frontline")
+        {
+            dutyLocation = "FL";
+        }
+        else if (dutyLocation == "Rival Wings")
+        {
+            dutyLocation = "RW";
+        }
+
+        return dutyLocation;
+    }
+
     public string GetLocalPlayerName()
     {
         return ClientState.LocalPlayer?.Name.ToString();
@@ -203,87 +290,7 @@ public sealed class Plugin : IDalamudPlugin
 
             if (reducedText)
             {
-                if (dutyLocation.Contains("Dungeons "))
-                {
-                    var pattern = @"Dungeons \(Lv\. (\d+-\d+|\d+)";
-                    var r = new Regex(pattern);
-                    var m = r.Match(dutyLocation);
-                    dutyLocation = m.Groups[1].Value;
-                }
-                else if (dutyLocation.Contains("Alliance Raids"))
-                {
-                    if (dutyLocation.Contains("A Realm Reborn"))
-                    {
-                        dutyLocation = "ARR";
-                    }
-                    else if (dutyLocation.Contains("Heavensward"))
-                    {
-                        dutyLocation = "HW";
-                    }
-                    else if (dutyLocation.Contains("Stormblood"))
-                    {
-                        dutyLocation = "StB";
-                    }
-                    else if (dutyLocation.Contains("Shadowbringers"))
-                    {
-                        dutyLocation = "ShB";
-                    }
-                    else if (dutyLocation.Contains("Endwalker"))
-                    {
-                        dutyLocation = "EW";
-                    }
-                    else if (dutyLocation.Contains("Dawntrail"))
-                    {
-                        dutyLocation = "DT";
-                    }
-                    dutyLocation += " AR";
-                }
-                else if (dutyLocation.Contains("of Bahamut"))
-                {
-                    // May be problematic if they go back to specific "Turn x" objectives
-                    var pattern = @"(.*) of Bahamut";
-                    var r = new Regex(pattern);
-                    var m = r.Match(dutyLocation);
-                    dutyLocation = m.Groups[1].Value;
-                }
-                else if (dutyLocation.Contains("-heavyweight"))
-                {
-                    var pattern = @"(AAC) \w+-heavyweight (.*)";
-                    var r = new Regex(pattern);
-                    var m = r.Match(dutyLocation);
-                    dutyLocation = $"{m.Groups[1].Value} {m.Groups[2].Value}";
-                }
-                else if (dutyLocation.Contains("Extreme"))
-                {
-                    var pattern = @"(?:the )?(.*) \(Extreme\)";
-                    var r = new Regex(pattern);
-                    var m = r.Match(dutyLocation);
-                    dutyLocation = m.Groups[1].Value;
-                    if (dutyLocation.Contains("Containment Bay"))
-                    {
-                        var splitCB = dutyLocation.Split(' ');
-                        dutyLocation = splitCB[2];
-                    }
-                }
-                else if (dutyLocation.Contains("Minstrel's Ballad"))
-                {
-                    var pattern = @"the Minstrel's Ballad: (.*)";
-                    var r = new Regex(pattern);
-                    var m = r.Match(dutyLocation);
-                    dutyLocation = m.Groups[1].Value;
-                }
-                else if (dutyLocation == "Crystalline Conflict")
-                {
-                    dutyLocation = "CC";
-                }
-                else if (dutyLocation == "Frontline")
-                {
-                    dutyLocation = "FL";
-                }
-                else if (dutyLocation == "Rival Wings")
-                {
-                    dutyLocation = "RW";
-                }
+                dutyLocation = ReduceWTDutyName(dutyLocation);
             }
 
             if (displayType == "copy")

--- a/WondrousTailsCopier/Windows/ComparisonWindow.cs
+++ b/WondrousTailsCopier/Windows/ComparisonWindow.cs
@@ -531,7 +531,7 @@ public class ComparisonWindow : Window, IDisposable
         ImGui.SameLine();
         if (ImGui.Button("Import Your Book"))
         {
-            Plugin.ToClipboard();
+            Plugin.ToClipboard(", ");
             ParseClipboard();
             CompileBooks();
             OrganizeObjectives();

--- a/WondrousTailsCopier/Windows/MainWindow.cs
+++ b/WondrousTailsCopier/Windows/MainWindow.cs
@@ -52,7 +52,7 @@ public class MainWindow : Window, IDisposable
 
         if (Plugin.HasWT())
         {
-            ImGui.Text(Plugin.GetWTNames("list"));
+            ImGui.Text(Plugin.GetWTNames("\n"));
             ImGui.Spacing();
 
             if (ImGui.Checkbox("Use Reduced Text", ref reducedTextValue))
@@ -74,7 +74,7 @@ public class MainWindow : Window, IDisposable
             }
             if (ImGui.Button("Copy to Clipboard"))
             {
-                Plugin.ToClipboard();
+                Plugin.ToClipboard(", ");
             }
             if (ImGui.Button("Book Club!"))
             {


### PR DESCRIPTION
- **shorten config variable names in GetWTNames()**
- **factor out GetWTDutyList() function from GetWTNames()**
- **factor duty name reduction to ReduceWTDutyName()**
- **convert reducedText to a Select call**
- **add "need" string to dutyList before joining strings**
- **replace loop with string.Join**
- **use GetWTDutyList in RemainingObjections()**
- **pass the separator string directly instead of a displayType value**
- **use var instead of bool for variable names in GetWTNames()**
